### PR TITLE
Loadbalancer + NFS for Wordpress

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
+
   config.vm.define 'database' do |db|
     db.vm.box = "generic/ubuntu2004"
     db.ssh.insert_key = false
@@ -21,6 +22,8 @@ Vagrant.configure("2") do |config|
     ansible.extra_vars = { ansible_python_interpreter:"/usr/bin/python3.8" }
     end
   end
+
+
   config.vm.define 'wordpress1' do |wp|
     wp.vm.box = "generic/ubuntu2004"
     wp.ssh.insert_key = false
@@ -37,10 +40,15 @@ Vagrant.configure("2") do |config|
     wp.vm.provision "ansible_local" do |ansible|
       ansible.playbook = "wordpress.yaml"
     ansible.verbose="v"
-    ansible.extra_vars = { ansible_python_interpreter:"/usr/bin/python3.8" }
+    ansible.extra_vars = { 
+      ansible_python_interpreter: "/usr/bin/python3.8",
+      host_ip: "192.168.50.21"
+    }
     end
   end
-  config.vm.define 'wordpress1' do |wp|
+
+
+  config.vm.define 'wordpress2' do |wp|
     wp.vm.box = "generic/ubuntu2004"
     wp.ssh.insert_key = false
     wp.ssh.username = "vagrant"
@@ -56,15 +64,19 @@ Vagrant.configure("2") do |config|
     wp.vm.provision "ansible_local" do |ansible|
       ansible.playbook = "wordpress.yaml"
     ansible.verbose="v"
-    ansible.extra_vars = { ansible_python_interpreter:"/usr/bin/python3.8" }
+    ansible.extra_vars = { 
+      ansible_python_interpreter: "/usr/bin/python3.8",
+      host_ip: "192.168.50.22"
+    }
     end
   end
+
   config.vm.define 'lb' do |lb|
     lb.vm.box = "generic/ubuntu2004"
     lb.ssh.insert_key = false
     lb.ssh.username = "vagrant"
     lb.vm.network "private_network", ip: "192.168.50.2"
-    lb.vm.hostname = "wordpress"
+    lb.vm.hostname = "lb"
     lb.vm.synced_folder ".", "/vagrant"
     lb.vm.provider "virtualbox" do |vb|
       vb.gui = false
@@ -78,4 +90,6 @@ Vagrant.configure("2") do |config|
     ansible.extra_vars = { ansible_python_interpreter:"/usr/bin/python3.8" }
     end
   end
+
+
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,17 +23,36 @@ Vagrant.configure("2") do |config|
     end
   end
 
+  config.vm.define 'lb' do |lb|
+    lb.vm.box = "generic/ubuntu2004"
+    lb.ssh.insert_key = false
+    lb.ssh.username = "vagrant"
+    lb.vm.network "private_network", ip: "192.168.50.2"
+    lb.vm.hostname = "lb"
+    lb.vm.synced_folder ".", "/vagrant"
+    lb.vm.provider "virtualbox" do |vb|
+      vb.gui = false
+      vb.memory = 1024 
+      vb.linked_clone = false
+    end
+
+    lb.vm.provision "ansible_local" do |ansible|
+      ansible.playbook = "lb.yaml"
+    ansible.verbose="v"
+    ansible.extra_vars = { ansible_python_interpreter:"/usr/bin/python3.8" }
+    end
+  end
 
   config.vm.define 'wordpress1' do |wp|
     wp.vm.box = "generic/ubuntu2004"
     wp.ssh.insert_key = false
     wp.ssh.username = "vagrant"
     wp.vm.network "private_network", ip: "192.168.50.21"
-    wp.vm.hostname = "wordpress"
+    wp.vm.hostname = "wordpress1"
     wp.vm.synced_folder ".", "/vagrant"
     wp.vm.provider "virtualbox" do |vb|
       vb.gui = false
-      vb.memory = 256
+      vb.memory = 1024 
       vb.linked_clone = false
     end
 
@@ -42,7 +61,8 @@ Vagrant.configure("2") do |config|
     ansible.verbose="v"
     ansible.extra_vars = { 
       ansible_python_interpreter: "/usr/bin/python3.8",
-      host_ip: "192.168.50.21"
+      host_ip: "192.168.50.21",
+      host: "wordpress1"
     }
     end
   end
@@ -53,11 +73,11 @@ Vagrant.configure("2") do |config|
     wp.ssh.insert_key = false
     wp.ssh.username = "vagrant"
     wp.vm.network "private_network", ip: "192.168.50.22"
-    wp.vm.hostname = "wordpress"
+    wp.vm.hostname = "wordpress2"
     wp.vm.synced_folder ".", "/vagrant"
     wp.vm.provider "virtualbox" do |vb|
       vb.gui = false
-      vb.memory = 256
+      vb.memory = 1024
       vb.linked_clone = false
     end
 
@@ -66,28 +86,9 @@ Vagrant.configure("2") do |config|
     ansible.verbose="v"
     ansible.extra_vars = { 
       ansible_python_interpreter: "/usr/bin/python3.8",
-      host_ip: "192.168.50.22"
+      host_ip: "192.168.50.22",
+      host: "wordpress2"
     }
-    end
-  end
-
-  config.vm.define 'lb' do |lb|
-    lb.vm.box = "generic/ubuntu2004"
-    lb.ssh.insert_key = false
-    lb.ssh.username = "vagrant"
-    lb.vm.network "private_network", ip: "192.168.50.2"
-    lb.vm.hostname = "lb"
-    lb.vm.synced_folder ".", "/vagrant"
-    lb.vm.provider "virtualbox" do |vb|
-      vb.gui = false
-      vb.memory = 256
-      vb.linked_clone = false
-    end
-
-    lb.vm.provision "ansible_local" do |ansible|
-      ansible.playbook = "lb.yaml"
-    ansible.verbose="v"
-    ansible.extra_vars = { ansible_python_interpreter:"/usr/bin/python3.8" }
     end
   end
 

--- a/database.yaml
+++ b/database.yaml
@@ -2,6 +2,58 @@
 - name: Setup database
   hosts: database
   tasks:
+    - name: Update repositories 
+      become: true
+      apt:
+        update_cache: yes
+        cache_valid_time: 86400 #A day
+        
+    - name: install mysql server
+      become: true
+      apt:
+        name: 
+          - mysql-server
+          - python3-pymysql  
+        state: present
 
-    - name: message to remove
-      command: echo 'Here you gonna put all tasks and roles that gonna setup database'
+        
+# Set MySQL root Password on Ansible/Ubuntu - https://linuxhint.com/set_mysql_root_password_ansible/ 
+    - name: Enable empty password for MySQL root user
+      become: true
+      shell: mysql -u root -e 'UPDATE mysql.user SET plugin="mysql_native_password"
+       WHERE user="root" AND host="localhost"; FLUSH PRIVILEGES;'
+
+    - name: Create SQL user 
+      mysql_user:
+        login_user: 'root'
+        login_password: ''
+        name: wp_user
+        host: '%'
+        password: wp_password
+        priv: "*.*:ALL"
+        state: present
+     
+    - name: Create DB for wordpress
+      mysql_db:
+        login_user: 'root'
+        login_password: ''
+        name: wp_db
+        state: present
+    
+    - name: Open MySQL port
+      become: true
+      ufw:
+        rule: allow
+        port: 3306
+        proto: tcp
+
+    - name: Update MySQL config
+      become: true
+      copy: src=/vagrant/mysqld.cnf dest=/etc/mysql/mysql.conf.d/ 
+
+    - name: Restart MySQL
+      become: true
+      systemd:
+        name: mysql
+        state: restarted
+

--- a/database.yaml
+++ b/database.yaml
@@ -49,8 +49,11 @@
 
     - name: Update MySQL config
       become: true
-      copy: src=/vagrant/mysqld.cnf dest=/etc/mysql/mysql.conf.d/ 
+      copy: src=/vagrant/mysqld.cnf dest=/etc/mysql/mysql.conf.d/
+      notify:
+      - Restart MySQL
 
+  handlers:
     - name: Restart MySQL
       become: true
       systemd:

--- a/default
+++ b/default
@@ -1,0 +1,22 @@
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+
+	root /var/www/html/wordpress;
+
+	index index.php index.html index.htm;
+
+	#server_name localhost;
+	server_name XXXXXX;
+
+	location / {
+		try_files $uri $uri/ =404;
+	}
+
+	location ~ \.php$ {
+		include snippets/fastcgi-php.conf;
+	
+		fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
+	}
+}
+

--- a/exports
+++ b/exports
@@ -1,0 +1,1 @@
+/home/wordpress *(rw,no_root_squash)

--- a/lb.yaml
+++ b/lb.yaml
@@ -20,6 +20,8 @@
         src: /vagrant/load_balancer.conf
         dest: /etc/nginx/conf.d/nginx.conf
         force: yes
+      notify:
+        - Refresh nginx
 
     - name: Delete Redundant Nginx Settings
       become: true
@@ -30,11 +32,6 @@
         - /etc/nginx/sites-enabled/default
         - /etc/nginx/sites-available/default  
 
-    - name: Refresh nginx
-      become: true
-      systemd: 
-        name: nginx
-        state: reloaded
 
     - name: Install NFS server package
       become: true 
@@ -60,13 +57,9 @@
         src: /vagrant/exports
         dest: /etc/exports
         force: yes
+      notify:
+        - Refresh NFS server service
 
-
-    - name: Refresh NFS server service
-      become: true 
-      systemd:     
-        name: nfs-kernel-server
-        state: started
   
     - name: Install Firewalld
       become: true 
@@ -96,3 +89,16 @@
     - name: Refreshing Firewall
       become: true 
       shell: 'firewall-cmd --reload'
+
+  handlers:
+    - name: Refresh nginx
+      become: true
+      systemd: 
+        name: nginx
+        state: reloaded
+
+    - name: Refresh NFS server service
+      become: true 
+      systemd:     
+        name: nfs-kernel-server
+        state: started

--- a/lb.yaml
+++ b/lb.yaml
@@ -1,7 +1,96 @@
 ---
-- name: Deploy Load Balancer
-  hosts: wordpress
+- name: Setup Load Balancer
+  hosts: loadBalancer
   tasks:
+    - name: Update repositories 
+      become: true
+      apt:
+        update_cache: yes
+        cache_valid_time: 86400 #A day
 
-    - name: message to remove
-      command: echo 'Here you gonna put all tasks and roles that gonna setup Load Balancer'
+    - name: Install Nginx
+      become: true
+      apt:
+        name: nginx 
+        state: present
+
+    - name: Open firewall for nginx
+      become: true
+      ufw:
+        rule: allow
+        name: 'Nginx Full'
+    
+    - name: Copy NGINX settings file
+      become: true
+      copy:
+        src: /vagrant/load_balancer.conf
+        dest: /etc/nginx/conf.d/nginx.conf
+        force: yes
+
+    - name: Delete Redundant Nginx Settings
+      become: true
+      file:
+        state: absent
+        path: '{{ item }}'
+      with_items:
+        - /etc/nginx/sites-enabled/default
+        - /etc/nginx/sites-available/default  
+
+    - name: Refresh nginx
+      become: true
+      systemd: 
+        name: nginx
+        state: reloaded
+
+    - name: Install NFS server package
+      become: true 
+      apt:
+        name: nfs-kernel-server 
+        state: present 
+
+    - name: Checking if Wordpress is installed
+      stat: path=/home/wordpress
+      register: wp_installed
+
+    - name: Install Wordpress
+      become: true
+      unarchive:
+        src: https://wordpress.org/latest.tar.gz
+        dest: /home
+        remote_src: true
+      when: not wp_installed.stat.exists
+
+    - name: Loading the etc/exports file 
+      become: true
+      copy:
+        src: /vagrant/exports
+        dest: /etc/exports
+        force: yes
+
+
+    - name: Refresh NFS server service
+      become: true 
+      systemd:     
+        name: nfs-kernel-server
+        state: started
+  
+    - name: Install Firewalld
+      become: true 
+      apt:
+        name: firewalld
+        state: present
+
+    - name: Configuring Firewall
+      become: true 
+      shell: 'firewall-cmd --add-service {{item}}'
+      with_items:
+        - nfs
+        - nfs --permanent
+        - mountd
+        - mountd --permanent
+        - rpc-bind
+        - rpc-bind --permanent  
+
+    - name: Enabling the etc/exports file 
+      become: true
+      shell: "exportfs -a" 

--- a/lb.yaml
+++ b/lb.yaml
@@ -13,12 +13,6 @@
       apt:
         name: nginx 
         state: present
-
-    - name: Open firewall for nginx
-      become: true
-      ufw:
-        rule: allow
-        name: 'Nginx Full'
     
     - name: Copy NGINX settings file
       become: true

--- a/lb.yaml
+++ b/lb.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Setup Load Balancer
-  hosts: loadBalancer
+  hosts: lb 
   tasks:
     - name: Update repositories 
       become: true
@@ -94,3 +94,11 @@
     - name: Enabling the etc/exports file 
       become: true
       shell: "exportfs -a" 
+
+    - name: Opening Nginx with Firewalld
+      become: true 
+      shell: 'firewall-cmd --permanent --zone=public --add-port=80/tcp'
+    
+    - name: Refreshing Firewall
+      become: true 
+      shell: 'firewall-cmd --reload'

--- a/load_balancer.conf
+++ b/load_balancer.conf
@@ -1,0 +1,12 @@
+  upstream backend {
+    server 192.168.50.21;
+    server 192.168.50.22;
+  }
+
+  server {
+    listen 80;
+
+    location / {
+      proxy_pass http://backend;
+    }
+  }

--- a/mysqld.cnf
+++ b/mysqld.cnf
@@ -1,0 +1,78 @@
+#
+# The MySQL database server configuration file.
+#
+# One can use all long options that the program supports.
+# Run program with --help to get a list of available options and with
+# --print-defaults to see which it would actually understand and use.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+# Here is entries for some specific programs
+# The following values assume you have at least 32M ram
+
+[mysqld]
+#
+# * Basic Settings
+#
+user		= mysql
+# pid-file	= /var/run/mysqld/mysqld.pid
+# socket	= /var/run/mysqld/mysqld.sock
+# port		= 3306
+# datadir	= /var/lib/mysql
+
+
+# If MySQL is running as a replication slave, this should be
+# changed. Ref https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_tmpdir
+# tmpdir		= /tmp
+#
+# Instead of skip-networking the default is now to listen only on
+# localhost which is more compatible and is not less secure.
+bind-address		= 0.0.0.0
+mysqlx-bind-address	= 127.0.0.1
+#
+# * Fine Tuning
+#
+key_buffer_size		= 16M
+# max_allowed_packet	= 64M
+# thread_stack		= 256K
+
+# thread_cache_size       = -1
+
+# This replaces the startup script and checks MyISAM tables if needed
+# the first time they are touched
+myisam-recover-options  = BACKUP
+
+# max_connections        = 151
+
+# table_open_cache       = 4000
+
+#
+# * Logging and Replication
+#
+# Both location gets rotated by the cronjob.
+#
+# Log all queries
+# Be aware that this log type is a performance killer.
+# general_log_file        = /var/log/mysql/query.log
+# general_log             = 1
+#
+# Error log - should be very few entries.
+#
+log_error = /var/log/mysql/error.log
+#
+# Here you can see queries with especially long duration
+# slow_query_log		= 1
+# slow_query_log_file	= /var/log/mysql/mysql-slow.log
+# long_query_time = 2
+# log-queries-not-using-indexes
+#
+# The following can be used as easy to replay backup logs or for replication.
+# note: if you are setting up a replication slave, see README.Debian about
+#       other settings you may need to change.
+# server-id		= 1
+# log_bin			= /var/log/mysql/mysql-bin.log
+# binlog_expire_logs_seconds	= 2592000
+max_binlog_size   = 100M
+# binlog_do_db		= include_database_name
+# binlog_ignore_db	= include_database_name

--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -1,7 +1,128 @@
 ---
 - name: Deploy Wordpress
-  hosts: wordpress
+  hosts: wordpress 
   tasks:
 
-    - name: message to remove
-      command: echo 'Here you gonna put all tasks and roles that gonna setup Wordpress application'
+    - name: Update repositories 
+      become: true
+      apt:
+        update_cache: yes
+        cache_valid_time: 86400 #A day
+
+    - name: install php dependencies
+      become: true
+      apt:
+        name:
+          - php-cli
+          - php-fpm
+          - php-mysql
+          - php-json
+          - php-opcache
+          - php-mbstring
+          - php-xml
+          - php-gd
+          - php-curl
+        state: present
+     
+    - name: install MySQL Client
+      become: true
+      apt:
+        name: 
+          - mysql-client
+          - python3-pymysql  
+        state: present
+            
+    - name: Install nginx
+      become: true
+      apt:
+        name: nginx 
+        state: present
+
+    - name: Install NFS client package
+      become: true 
+      apt:
+        name: nfs-common
+        state: present 
+
+    - name: Open firewall for nginx
+      become: true
+      ufw:
+        rule: allow
+        name: 'Nginx Full'
+    
+    - name: Copy NGINX default settings file
+      become: true
+      copy:
+        src: /vagrant/default
+        dest: /etc/nginx/sites-enabled
+        force: yes
+
+    - name: Substitute IP address on nginx file
+      become: true
+      lineinfile:
+        path: /etc/nginx/sites-enabled/default
+        state: present
+        regexp: '\sserver_name.*$'
+        line: 'server_name {{ host_ip }};'
+
+
+    - name: Check if wp-cli exists
+      stat: path="/bin/wp"
+      register: wpcli_exist
+
+    - name: Download wp-cli
+      become: true
+      get_url:
+        url="https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar"
+        dest="/bin/wp"
+        force_basic_auth=yes
+        mode=0755
+      when: not wpcli_exist.stat.exists
+
+    - name: Checking if Wordpress folder is mounted
+      stat: path=/var/www/html/wordpress
+      register: wp_mounted
+
+    - name: Creating wordpress folder for mount    
+      become: true 
+      file:
+        path: /var/www/html/wordpress
+        state: directory
+      when: not wp_mounted.stat.exists
+
+
+    - name: Mounting the wp NFS directory    
+      become: true 
+      mount:
+        src: 192.168.50.2:/home/wordpress      
+        path: /var/www/html/wordpress
+        state: mounted
+        fstype: nfs
+      when: not wp_mounted.stat.exists
+
+
+    - name: Configure Wordpress DB Connection
+      become: true
+      copy:
+        src: /vagrant/wp-config.php
+        dest: /var/www/html/wordpress
+
+    - name: Configure Wordpress Admin User
+      become: true
+      shell: 'wp core install --url="192.168.50.2" --title="Mi Blog" --admin_user=admin --admin_email=danpal@example.com --admin_password="!2three456." --path=/var/www/html/wordpress --allow-root'
+
+  
+    - name: Activating twentynineteen wp theme
+      become: true
+      shell: 'wp theme install twentynineteen --activate --path=/var/www/html/wordpress --allow-root'  
+
+    - name: Giving Write permissions to the Wordpress Folder
+      become: true
+      shell: "chown -R www-data: /var/www/html/wordpress" 
+
+    - name: Refresh nginx
+      become: true
+      systemd: 
+        name: nginx
+        state: reloaded
+

--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -48,7 +48,7 @@
       become: true
       ufw:
         rule: allow
-        name: 'Nginx Full'
+        port: 80
     
     - name: Copy NGINX default settings file
       become: true
@@ -67,11 +67,6 @@
         regexp: '\sserver_name.*$'
         line: 'server_name {{ host_ip }};'
 
-
-    - name: Check if wp-cli exists
-      stat: path="/bin/wp"
-      register: wpcli_exist
-
     - name: Download wp-cli
       become: true
       get_url:
@@ -79,7 +74,6 @@
         dest="/bin/wp"
         force_basic_auth=yes
         mode=0755
-      when: not wpcli_exist.stat.exists
 
     - name: Checking if Wordpress folder is mounted
       stat: path=/var/www/html/wordpress

--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -56,6 +56,8 @@
         src: /vagrant/default
         dest: /etc/nginx/sites-enabled
         force: yes
+      notify:
+        - Refresh nginx        
 
     - name: Substitute IP address on nginx file
       become: true
@@ -119,7 +121,8 @@
     - name: Giving Write permissions to the Wordpress Folder
       become: true
       shell: "chown -R www-data: /var/www/html/wordpress" 
-
+      
+  handlers:
     - name: Refresh nginx
       become: true
       systemd: 

--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Deploy Wordpress
-  hosts: wordpress 
+  hosts: "{{ host }}" 
   tasks:
 
     - name: Update repositories 

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,0 +1,51 @@
+<?php
+
+/** The name of the database for WordPress */
+define( 'DB_NAME', 'wp_db' );
+
+/** MySQL database username */
+define( 'DB_USER', 'wp_user' );
+
+/** MySQL database password */
+define( 'DB_PASSWORD', 'wp_password' );
+
+/** MySQL hostname */
+define( 'DB_HOST', '192.168.50.10' );
+
+/** Database Charset to use in creating database tables. */
+define( 'DB_CHARSET', 'utf8' );
+
+/** The Database Collate type. Don't change this if in doubt. */
+define( 'DB_COLLATE', '' );
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ */
+define('AUTH_KEY', 't M&L&56FEZS@I$(aZ9?,R7O!pBQ~q=-A[qb]zA-YD;2;r`64nr+fTTaC+/9)VC|');
+define('SECURE_AUTH_KEY', 'IP,~&5<3`d8*]gIKhN/Up/{I:P{rbGsFOvn&2wY|gcKu@%{l#$M/RHa|5iRagn/2');
+define('LOGGED_IN_KEY', 'u-dA~MEE&X@|}2OK,-n3v,vgoe$NJCWl!NOIo<Sc9H7b+CI{.v-}>xTG8^b~|qi!');
+define('NONCE_KEY', '>6Q+*Kp&~vA|DAkC,1e-l&J3n=oS##-qFl./G!H_d|i`-^H5Z7A`Ioh8c}k$/$Ct');
+define('AUTH_SALT', '}MfxME5xrgNe5|$oN5 K#tiiaR^JK|:VV[k&I=%XcR}#Y+7~1^@_D:p<$VyUZ4da');
+define('SECURE_AUTH_SALT', '%&+MZ|H@1Xx|+4<P9!tWj)Vf04</hg-*f9+ab:c9%qoOvuUVw }cRcDhDw/K@]+s');
+define('LOGGED_IN_SALT', 'OeR/5<eg:*+1$m%}{FW !D[WxUtcS6rKI*E;2hwCs?~C!UkAd-IT%?.fnbqz@rSr');
+define('NONCE_SALT', 'j.ST.MY~0<Ws!Fe:lw%fy6K*Eh$mwQ7Z4oTM7w!zH:[]L1#Hz6CIf$:Z9n5}yFHQ');
+/**#@-*/
+
+$table_prefix = 'wp_';
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ */
+define( 'WP_DEBUG', false );
+
+/* That's all, stop editing! Happy publishing. */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once ABSPATH . 'wp-settings.php';


### PR DESCRIPTION
I implemented a LB that can now run wp instances in an independent manner. This was achieved by setting up a NFS that allows to share a single "core wordpress" folder between any number of instances. I put the folder inside the load balancer machine to make things easier, but ideally, I'd create a dedicated host just for NFS purposes.

As a side note, I had to increase the memory size to 1024 for all the virtual machines. This because using 256 was incredible slow for both VM creation and provisioning. 